### PR TITLE
1027 - Show 'wrong network' msg when using a custom chain such as BSC or any other unsupported network

### DIFF
--- a/lib/components/IndexContent.jsx
+++ b/lib/components/IndexContent.jsx
@@ -40,11 +40,7 @@ const demoPools = {
 }
 
 export const IndexContent = (props) => {
-  return (
-    <>
-      <PoolsLists />
-    </>
-  )
+  return <PoolsLists />
 }
 
 const PoolsLists = () => {
@@ -90,23 +86,23 @@ const ReferencePoolCard = () => {
   }
 
   const networks = {
-    ropsten: {
+    'ropsten': {
       value: 'ropsten',
       view: 'Ropsten'
     },
-    rinkeby: {
+    'rinkeby': {
       value: 'rinkeby',
       view: 'Rinkeby'
     },
-    mainnet: {
+    'mainnet': {
       value: 'mainnet',
       view: 'Mainnet'
     },
-    ['poa-sokol']: {
+    'poa-sokol': {
       value: 'poa-sokol',
       view: 'Sokol (POA)'
     },
-    local: {
+    'local': {
       value: 'local',
       view: 'Local'
     }

--- a/lib/components/Layout.jsx
+++ b/lib/components/Layout.jsx
@@ -4,6 +4,7 @@ import { Slide, ToastContainer } from 'react-toastify'
 import { Footer } from 'lib/components/Footer'
 import { Meta } from 'lib/components/Meta'
 import { Nav } from 'lib/components/Nav'
+import { StaticNetworkNotificationBanner } from 'lib/components/StaticNetworkNotificationBanner'
 
 export const Layout = (props) => {
   const { children } = props
@@ -11,6 +12,7 @@ export const Layout = (props) => {
   return (
     <>
       <Meta />
+      <StaticNetworkNotificationBanner />
 
       <div
         className='flex flex-col w-full'

--- a/lib/components/StaticNetworkNotificationBanner.jsx
+++ b/lib/components/StaticNetworkNotificationBanner.jsx
@@ -32,6 +32,10 @@ export const StaticNetworkNotificationBanner = ({}) => {
     networkWords = `${networkName} 👍`
   }
 
+  if (networkSupported) {
+    return null
+  }
+
   return (
     <div
       className={classnames('text-sm sm:text-base lg:text-lg sm:px-6 py-2 sm:py-3', {
@@ -39,7 +43,7 @@ export const StaticNetworkNotificationBanner = ({}) => {
         'text-default bg-purple-1': networkSupported
       })}
     >
-      <div className='text-center px-4'>
+      <div className='text-center px-4 font-bold'>
         This works on {supportedNames}. Your wallet is currently set to{' '}
         <span className='font-bold'>{networkWords}</span>
       </div>

--- a/lib/components/WalletContextProvider.jsx
+++ b/lib/components/WalletContextProvider.jsx
@@ -148,11 +148,21 @@ const doConnectWallet = async (walletType, setOnboardState) => {
 const connectWallet = (w, setOnboardState) => {
   Cookies.set(SELECTED_WALLET_COOKIE_KEY, w.name, cookieOptions)
 
+  const provider = new ethers.providers.Web3Provider(w.provider, 'any')
+  provider.on('network', (newNetwork, oldNetwork) => {
+    // When a Provider makes its initial connection, it emits a "network"
+    // event with a null oldNetwork along with the newNetwork. So, if the
+    // oldNetwork exists, it represents a changing network
+    if (oldNetwork) {
+      window.location.reload()
+    }
+  })
+
   setOnboardState((previousState) => ({
     ...previousState,
     address: undefined,
     wallet: w,
-    provider: new ethers.providers.Web3Provider(w.provider)
+    provider
   }))
 }
 

--- a/lib/components/WalletContextProvider.jsx
+++ b/lib/components/WalletContextProvider.jsx
@@ -149,14 +149,6 @@ const connectWallet = (w, setOnboardState) => {
   Cookies.set(SELECTED_WALLET_COOKIE_KEY, w.name, cookieOptions)
 
   const provider = new ethers.providers.Web3Provider(w.provider, 'any')
-  provider.on('network', (newNetwork, oldNetwork) => {
-    // When a Provider makes its initial connection, it emits a "network"
-    // event with a null oldNetwork along with the newNetwork. So, if the
-    // oldNetwork exists, it represents a changing network
-    if (oldNetwork) {
-      window.location.reload()
-    }
-  })
 
   setOnboardState((previousState) => ({
     ...previousState,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,7 +20,7 @@ import { contractVersions } from '@pooltogether/current-pool-data'
 
 export const SENTINEL_ADDRESS = '0x0000000000000000000000000000000000000001'
 
-export const SUPPORTED_NETWORKS = [1, 3, 4, 42, 31337, 1234]
+export const SUPPORTED_NETWORKS = [1, 4, 42, 77, 31337, 1234]
 
 export const SECONDS_PER_BLOCK = 14
 

--- a/lib/utils/chainIdToName.js
+++ b/lib/utils/chainIdToName.js
@@ -6,6 +6,8 @@ export function chainIdToName(chainId) {
       return 'ropsten'
     case 4:
       return 'rinkeby'
+    case 5:
+      return 'goerli'
     case 42:
       return 'kovan'
     case 77:
@@ -13,11 +15,11 @@ export function chainIdToName(chainId) {
     case 99:
       return 'poa'
     case 1234:
-      return 'localhost'
+      return 'local'
     case 31337:
-      return 'localhost'
+      return 'local'
     default:
-      return 'unknown'
+      return 'unknown network'
   }
   throw new Error(`unknown network chainId: ${chainId}`)
 }

--- a/lib/utils/nameToChainId.js
+++ b/lib/utils/nameToChainId.js
@@ -6,7 +6,7 @@ export function nameToChainId(networkName) {
       return 4
     case 'kovan':
       return 42
-    case 'localhost':
+    case 'local':
       return 31337
     case 'poa-sokol':
       return 77

--- a/lib/utils/networkColorClassname.js
+++ b/lib/utils/networkColorClassname.js
@@ -8,6 +8,8 @@ export const networkColorClassname = (networkId) => {
   } else if (networkId === 1234) {
     return 'text-teal'
   } else if (networkId === 42) {
-    return 'text-highlight-1'
+    return 'text-default-soft'
+  } else {
+    return 'text-white'
   }
 }


### PR DESCRIPTION
* show the warning banner saying they're on an unknown network
* add poa-sokol to list of supported networks
* prevent the dreaded 'underlying network changed' issue with ethers 5 by using the 2nd param 'any' and having the page reload when someone changes the network