### PR TITLE
Pool-1116 Pool index pages not linked to the users wallet

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,8 +1,9 @@
-/:poolAlias/home /[poolAlias]/home.html     200
-/:poolAlias/manage /[poolAlias]/manage.html 200
-/:poolAlias /[poolAlias].html               200
+/:poolAlias/home                              /[poolAlias]/home.html                              200
+/:poolAlias/manage                            /[poolAlias]/manage.html                            200
+/:poolAlias                                   /[poolAlias].html                                   200
 
-/pools/:networkName/:prizePoolAddress/home /pools/[networkName]/[prizePoolAddress]/home.html     200
-/pools/:networkName/:prizePoolAddress/manage /pools/[networkName]/[prizePoolAddress]/manage.html 200
-/pools/:networkName/:prizePoolAddress/admin /pools/[networkName]/[prizePoolAddress]/admin.html 200
-/pools/:networkName/:prizePoolAddress /pools/[networkName]/[prizePoolAddress].html               200
+/pools/:networkName/:prizePoolAddress/home    /pools/[networkName]/[prizePoolAddress]/home.html   200
+/pools/:networkName/:prizePoolAddress/manage  /pools/[networkName]/[prizePoolAddress]/manage.html 200
+/pools/:networkName/:prizePoolAddress/admin   /pools/[networkName]/[prizePoolAddress]/admin.html  200
+/pools/:networkName/:prizePoolAddress         /pools/[networkName]/[prizePoolAddress].html        200
+/pools/:networkName                           /pools/[networkName].html                           200

--- a/lib/components/ChangeWalletNetworkNotificationBanner.jsx
+++ b/lib/components/ChangeWalletNetworkNotificationBanner.jsx
@@ -7,7 +7,6 @@ import { WalletContext } from 'lib/components/WalletContextProvider'
 import { WALLETS } from 'lib/constants'
 import { NotificationBanner } from 'lib/components/NotificationBanners'
 import { NETWORK } from 'lib/utils/networks'
-import { ButtonLink } from 'lib/components/ButtonLink'
 
 export const ChangeWalletNetworkNotificationBanner = (props) => {
   const { walletConnected, walletMatchesNetwork, walletNetwork, view, chainId } = useNetwork()
@@ -15,7 +14,7 @@ export const ChangeWalletNetworkNotificationBanner = (props) => {
   if (!walletConnected || walletMatchesNetwork) return null
 
   return (
-    <NotificationBanner className='bg-teal'>
+    <NotificationBanner className='bg-teal' canClose>
       <ChangeWalletNetworkNotification
         chainId={chainId}
         walletNetwork={walletNetwork}

--- a/lib/components/ChangeWalletNetworkNotificationBanner.jsx
+++ b/lib/components/ChangeWalletNetworkNotificationBanner.jsx
@@ -49,7 +49,7 @@ const ChangeWalletNetworkNotification = (props) => {
     <div className='flex flex-col sm:flex-row justify-between items-center'>
       <span>
         👋 Your wallet is currently set to <b>{walletChainName}</b>. Please connect to{' '}
-        <b>{poolChainName}</b> to participate in this pool.
+        <b>{poolChainName}</b> to participate.
         <br className='hidden xs:block' />
         {showBadWalletMessage && (
           <span>

--- a/lib/components/CustomYieldNotificationBanner.jsx
+++ b/lib/components/CustomYieldNotificationBanner.jsx
@@ -10,7 +10,7 @@ export const CustomYieldNotificationBanner = () => {
   if (prizePoolType !== PRIZE_POOL_TYPE.yield) return null
 
   return (
-    <NotificationBanner className='bg-purple-2'>
+    <NotificationBanner className='bg-purple-2' canClose>
       <CustomYieldNotification />
     </NotificationBanner>
   )

--- a/lib/components/IndexContent.jsx
+++ b/lib/components/IndexContent.jsx
@@ -76,7 +76,6 @@ const PoolsLists = () => {
 
   return (
     <>
-      <UnsupportedNetworkCard />
       <UsersPoolsCard createdPrizePools={createdPrizePools} tokenBalances={tokenBalances} />
       <GovernancePoolsCard createdPrizePools={createdPrizePools} tokenBalances={tokenBalances} />
       <DemoPoolsCard />
@@ -84,24 +83,6 @@ const PoolsLists = () => {
       <ReferencePoolCard />
       <BuilderCard />
     </>
-  )
-}
-
-const UnsupportedNetworkCard = () => {
-  const { chainId } = useNetwork()
-
-  if (![NETWORK.matic, NETWORK.mumbai].includes(chainId)) return null
-
-  const networkName = NETWORK_DATA[chainId].view
-
-  return (
-    <div className='text-left mb-10 border-2 border-primary rounded-lg px-7 py-4 text-accent-1'>
-      <CardTitle noMargin>☹️ Full Index Unavailable for {networkName}</CardTitle>
-      <p>
-        Unfortunately due to limitations of {networkName} we can't dynamically compile a list of
-        created prize pools.
-      </p>
-    </div>
   )
 }
 
@@ -347,6 +328,7 @@ const AllPoolsCard = (props) => {
   const { createdPrizePools, tokenBalances } = props
 
   const walletContext = useContext(WalletContext)
+  const { chainId, view: networkView } = useNetwork()
   const [hideNoDeposits, setHideNoDeposits] = useState(createdPrizePools.length > 10)
   const [showFirstTen, setShowFirstTen] = useState(createdPrizePools.length > 10)
 
@@ -378,17 +360,19 @@ const AllPoolsCard = (props) => {
 
   if (createdPrizePools?.length === 0) return null
 
+  let tip = 'These pools created permissionlessly by anyone using the PoolTogether Builder'
+  if ([NETWORK.matic, NETWORK.mumbai].includes(chainId)) {
+    tip = `Unfortunately due to limitations of ${networkView} we can't dynamically compile a list of
+    created prize pools.`
+  }
+
   return (
     <Card>
       <Collapse
         title={
           <>
             🤿 All Pools
-            <Tooltip
-              id='all-pools'
-              className='ml-2 my-auto'
-              tip='These pools created permissionlessly by anyone using the PoolTogether Builder'
-            />
+            <Tooltip id='all-pools' className='ml-2 my-auto' tip={tip} />
           </>
         }
         containerClassName='mb-4 xs:mb-8'

--- a/pages/pools/[networkName]/index.jsx
+++ b/pages/pools/[networkName]/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+import { IndexContent } from 'lib/components/IndexContent'
+
+export default function IndexPage() {
+  return <IndexContent />
+}


### PR DESCRIPTION
- `/pools/[network]` will load the index page, for `network` regardless of what the users wallet is connected to
- Move the message about not being able to compile the full list of pools to a tooltip so it's less aggressive 